### PR TITLE
fix(docs): Fix broken antora links

### DIFF
--- a/docs/modules/ROOT/nav.adoc
+++ b/docs/modules/ROOT/nav.adoc
@@ -2,7 +2,7 @@
 
 * Generators
 ** xref:catalog-info.adoc[Catalog Info]
-** xref:template.adoc[Template]
+** xref:template-generator.adoc[Template Generator]
 
 * xref:client.adoc[Java Client]
 * xref:cli.adoc[Command Line Interface]

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -1,3 +1,3 @@
-:project-version: 0.3.1
+:project-version: 0.4.0
 
 :examples-dir: ./../examples/


### PR DESCRIPTION
- Update project version to `0.4.0` in documentation.
- Fixes #100
